### PR TITLE
Feature/cy 1592 decrease by 24h from last tx

### DIFF
--- a/index.js
+++ b/index.js
@@ -720,9 +720,15 @@ Kraken.prototype.listTradeHistoryForPeriod = function (fromDateTime, toDateTime,
 
 Kraken.prototype.listTrades = async function (latestTrade = null) {
   return new Promise((resolve, reject) => {
+    /** @var {Date} **/
     const latestTxDate = latestTrade && latestTrade.createTime
       ? latestTrade.createTime
       : new Date(0);
+
+    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    if (latestTxDate > twentyFourHoursAgo) {
+      latestTxDate.setHours(latestTxDate.getHours() - 24);
+    }
 
     this.listTradeHistoryForPeriod(latestTxDate, new Date(), (error, trades) => {
       if (error) {

--- a/test/unit/listTrades.test.js
+++ b/test/unit/listTrades.test.js
@@ -112,7 +112,8 @@ describe('#listTrades', function () {
     reqStub.yields(null, {}, JSON.stringify(getTradesResponse));
 
     const from = new Date();
-    from.setTime(from.getTime() - 60 * 60 * 1000);
+    // Outside of 24 hour period
+    from.setTime(from.getTime() - 25 * 60 * 60 * 1000);
 
     const krakenTrades = await kraken.listTrades({ createTime: from });
 
@@ -126,5 +127,24 @@ describe('#listTrades', function () {
     expect(krakenTrades).an('Array');
     expect(krakenTrades).length(expectedTrades.length);//Skip the one not within the time
     expect(krakenTrades).containSubset(expectedTrades);
+  });
+  it('should decrease 24h from the latestTxDate if it is within the last 24 hours ', async () => {
+    getTradesResponse.result = { trades };
+    reqStub.yields(null, {}, JSON.stringify(getTradesResponse));
+
+    const from = new Date();
+    from.setTime(from.getTime() - 20 * 60 * 60 * 1000);
+
+    const expectedTime = new Date(from.getTime() - 24 * 60 * 60 * 1000);
+    const krakenTrades = await kraken.listTrades({ createTime: from });
+
+    expect(reqStub.calledOnce).equal(true);
+    expect(reqStub.firstCall.args[0]).containSubset({
+      form: {
+        start: expectedTime.getTime() / 1000
+      }
+    });
+
+    expect(krakenTrades).an('Array');
   });
 });

--- a/test/unit/listTrades.test.js
+++ b/test/unit/listTrades.test.js
@@ -112,7 +112,7 @@ describe('#listTrades', function () {
     reqStub.yields(null, {}, JSON.stringify(getTradesResponse));
 
     const from = new Date();
-    // Outside of 24 hour period
+    // Outside the 24-hour period
     from.setTime(from.getTime() - 25 * 60 * 60 * 1000);
 
     const krakenTrades = await kraken.listTrades({ createTime: from });


### PR DESCRIPTION
Decreases latestTxDate by 24-hours from the current one, if it is within a 24 hour period from now.
This PR aims to address the issue of overlapping datetime when importing.