### PR TITLE
CY-1983: Use ordertxid instead of key from object as externalId

### DIFF
--- a/lib/ApiResponseConverter.js
+++ b/lib/ApiResponseConverter.js
@@ -173,7 +173,7 @@ function convertFromKrakenTrade(id, trade) {
 
 
   return [ null, {
-    externalId: id,
+    externalId: trade.ordertxid,
     timestamp: convertKrakenTimestampToISOString(trade.time),
     state: 'closed',
     baseCurrency,

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
     "test": "LOG_LEVEL=fatal mocha --config .mocharc.json",
     "test-watch": "LOG_LEVEL=info mocha --config .mocharc.json --watch"
   },
-  "version": "2.5.2"
+  "version": "2.5.3"
 }

--- a/test/unit/apiResponseConverter.test.js
+++ b/test/unit/apiResponseConverter.test.js
@@ -112,7 +112,7 @@ describe('#ApiResponseConverter', function () {
     it('convertFromKrakenTrade', () => {
       const id = 'TCWJEG-FL4SZ-3FKGH6';
       const [ err, trade ] = convertFromKrakenTrade(id, {
-        ordertxid: 'OQCLML-BW3P3-BUCMWZ',
+        ordertxid: id,
         postxid: 'TKH2SE-M7IF5-CFI7LT',
         pair: 'XETHZUSD',
         time: Date.now()/1000,

--- a/test/unit/listTradeHistoryForPeriod.test.js
+++ b/test/unit/listTradeHistoryForPeriod.test.js
@@ -111,6 +111,7 @@ describe('#listTradeHistoryForPeriod', function () {
         maker: true
       },
       'OO3QCQ-SOJXH-NWMZZF': {
+        ordertxid: 'OO3QCQ-SOJXH-NWMZZF',
         fee: '104.68207',
         vol: '24.91800000',
         cost: '58156.69775',
@@ -122,6 +123,7 @@ describe('#listTradeHistoryForPeriod', function () {
         status: 'closed'
       },
       'OOEEE3QCQ-SOJXH-NWMZZF': {
+        ordertxid: 'OOEEE3QCQ-SOJXH-NWMZZF',
         fee: '104.68207',
         vol: '24.91800000',
         cost: '58156.69775',
@@ -133,6 +135,7 @@ describe('#listTradeHistoryForPeriod', function () {
         status: 'closed'
       },
       'OOUEE3QCQ-SOJXH-NWMZZF': {
+        ordertxid: 'OOUEE3QCQ-SOJXH-NWMZZF',
         fee: '104.68207',
         vol: '24.91800000',
         cost: '58156.69775',
@@ -144,6 +147,7 @@ describe('#listTradeHistoryForPeriod', function () {
         status: 'closed'
       },
       'EOUEE3QCQ-SOJXH-NWMZZF': {
+        ordertxid: 'EOUEE3QCQ-SOJXH-NWMZZF',
         fee: '104.68207',
         vol: '24.91800000',
         cost: '58156.69775',
@@ -155,6 +159,7 @@ describe('#listTradeHistoryForPeriod', function () {
         status: 'closed'
       },
       'IOUEE3QCQ-SOJXH-NWMZZF': {
+        ordertxid: 'IOUEE3QCQ-SOJXH-NWMZZF',
         fee: '104.68207',
         vol: '24.91800000',
         cost: '58156.69775',
@@ -166,6 +171,7 @@ describe('#listTradeHistoryForPeriod', function () {
         status: 'closed'
       },
       'ROUEE3QCQ-SOJXH-NWMZZF': {
+        ordertxid: 'ROUEE3QCQ-SOJXH-NWMZZF',
         fee: '104.68207',
         vol: '24.91800000',
         cost: '58156.69775',
@@ -177,6 +183,7 @@ describe('#listTradeHistoryForPeriod', function () {
         status: 'closed'
       },
       'KOUEE3QCQ-SOJXH-NWMZZF': {
+        ordertxid: 'KOUEE3QCQ-SOJXH-NWMZZF',
         fee: '104.68207',
         vol: '24.91800000',
         cost: '58156.69775',
@@ -188,6 +195,7 @@ describe('#listTradeHistoryForPeriod', function () {
         status: 'closed'
       },
       'KYUEE3QCQ-SOJXH-NWMZZF': {
+        ordertxid: 'KYUEE3QCQ-SOJXH-NWMZZF',
         fee: '104.68207',
         vol: '24.91800000',
         cost: '58156.69775',
@@ -241,12 +249,14 @@ describe('#listTradeHistoryForPeriod', function () {
       expect(trades).length(trades.length);
       expect(trades).containSubset([
         {
+          externalId: 'OQCLML-BW3P3-BUCMWZ',
           baseCurrency: 'ETH',
           quoteCurrency: 'USD',
           baseAmount: 10000000000,
           quoteAmount: -30010
         },
         {
+          externalId: 'OACLML-BW3P3-BUCMWZ',
           baseCurrency: 'EUR',
           quoteCurrency: 'USD'
         },


### PR DESCRIPTION
This is to avoid duplicate entries due to using two different Id's